### PR TITLE
fix(plugin-virtual-module): file creation fail when module names contains slashes

### DIFF
--- a/packages/plugin-virtual-module/example/rspack.config.js
+++ b/packages/plugin-virtual-module/example/rspack.config.js
@@ -2,10 +2,11 @@ const { RspackVirtualModulePlugin } = require('../dist');
 
 const vmp = new RspackVirtualModulePlugin({
   '@theme': 'export default "theme"',
+  '@foo/bar': 'export default "foobar"',
 });
 
 setTimeout(() => {
-  vmp.writeModule('a', 'export default "123123"');
+  vmp.writeModule('@theme', 'export default "123123"');
 }, 2e3);
 
 /**

--- a/packages/plugin-virtual-module/example/src/App.jsx
+++ b/packages/plugin-virtual-module/example/src/App.jsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import reactLogo from './assets/react.svg';
 import './App.css';
 import s from '@theme';
+import t from '@foo/bar';
 
-console.log(s);
+console.log(s, t);
 
 function App() {
   const [count, setCount] = useState(0);

--- a/packages/plugin-virtual-module/package.json
+++ b/packages/plugin-virtual-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rspack-plugin-virtual-module",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/plugin-virtual-module/src/index.ts
+++ b/packages/plugin-virtual-module/src/index.ts
@@ -36,7 +36,7 @@ export class RspackVirtualModulePlugin implements RspackPluginInstance {
   apply(compiler: Compiler) {
     // Write the modules to the disk
     Object.entries(this.#staticModules).forEach(([path, content]) => {
-      fs.writeFileSync(this.#normalizePath(path), content);
+      this.writeModule(path, content);
     });
     const originalResolveModulesDir = compiler.options.resolve.modules || [
       'node_modules',


### PR DESCRIPTION
file creation will fail when virtual module names contains slashes. 
just reuse the existing file creation logic.